### PR TITLE
Add a newline at the end of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Real exchanges are much much more complicated than this.
 The code is open-sourced via the MIT Licence: see the LICENSE file for full text. 
 (copied from http://opensource.org/licenses/mit-license.php)
 
-Last update: Dave Cliff, October 25th 2012. 
+Last update: Dave Cliff, October 25th 2012.


### PR DESCRIPTION
When reading the readme with `cat` I saw there wasn't a newline at the end of it, this makes it harder to read and use on a terminal. I added one.
