### PR TITLE
fix: make PRZI available

### DIFF
--- a/BSE.py
+++ b/BSE.py
@@ -716,6 +716,9 @@ class Trader_PRZI(Trader):
                 elif self.optmzr == 'PRDE':
                     # differential evolution: seed initial strategies across whole space
                     strategy = self.mutate_strat(self.strats[0]['stratval'], 'uniform_bounded_range')
+                elif self.optmzr == None:
+                    # PRZI use the constant strategy
+                    pass
                 else:
                     sys.exit('bad self.optmzr when initializing PRZI strategies')
             self.strats.append({'stratval': strategy, 'start_t': start_time,


### PR DESCRIPTION
In the previous code, when the trader is set as "PRZI", `self.optimzr` is None, so the code will throw error 'bad self.optmzr when initializing PRZI strategies' and exit.
This commit fixed it and set the PRZI's r value as a constant value between s_min to s_max.